### PR TITLE
Skip empty lines when parsing gems

### DIFF
--- a/src/ManaMason/Blueprint.as
+++ b/src/ManaMason/Blueprint.as
@@ -102,6 +102,8 @@ package ManaMason
 		{
 			for each(var template:String in lines)
 			{
+				if (!template)
+					continue;
 				var gem:FakeGem = new FakeGem(-1, 0);
 				var parts:Array = template.split("=");
 				var props:Array = parts[1].split(",");


### PR DESCRIPTION
This should fix issue [#3](https://github.com/gemforce-team/ManaMason/issues/3).

Note: this is probably the first two lines of ActionScripts I'm writing. I didn't compile nor test it, so you probably want to double check this.